### PR TITLE
Fix missing dependencies

### DIFF
--- a/resources/meta/boot/environment.edn
+++ b/resources/meta/boot/environment.edn
@@ -9,8 +9,9 @@
                 [adzerk/boot-cljs            "2.0.0"]
                 [adzerk/boot-reload          "0.5.1"]
                 [boot/new                    "0.5.2"]
-                [degree9/boot-nodejs         "1.2.0"]
-                ;[degree9/boot-docker         "0.1.0-SNAPSHOT"    ]
+                [degree9/boot-nodejs         "1.2.0"
+                 :exclusions [boot/core]]
+                 ;[degree9/boot-docker         "0.1.0-SNAPSHOT"    ]
                 [degree9/boot-npm            "1.4.0"]
                 [degree9/boot-exec           "1.0.0"]
                 [degree9/boot-semver         "1.6.0"]
@@ -18,9 +19,15 @@
                 [degree9/boot-electron       "0.1.0"]
                 [degree9/boot-welcome        "1.0.0"]
                 [degree9/electron-cljs       "0.1.0"]
-                [degree9/featherscript       "0.4.0-SNAPSHOT"]
+
+                ;; featherscript relies on a version of feathers that doesn't
+                ;; exist in clojars yet
+                [degree9/featherscript       "0.4.0-SNAPSHOT"
+                 :exclusions [cljsjs/feathers]]
+                [cljsjs/feathers "2.0.0-pre.1-0"]
+
                 [degree9/nodejs-cljs         "0.1.0"]
-                [degree9/meta-template       "0.1.0-SNAPSHOT"]
+                [degree9/meta-template       "0.0.0"]
                 [hoplon/hoplon               "7.1.0-SNAPSHOT"]
                 [hoplon/brew                 "0.2.0-SNAPSHOT"]
                 [degree9/material-hl         "0.10.0"]


### PR DESCRIPTION
Without this, I couldn't even do `boot repl`, instead I would get:

```
clojure.lang.ExceptionInfo: The following artifacts could not be resolved: cljsjs:feathers:jar:2.0.1-0-0, degree9:meta-template:jar:0.1.0-SNAPSHOT: Could not find artifact cljsjs:feathers:jar:2.0.1-0-0 in clojars (https://repo.clojars.org/)
```

This issue also prevented me from creating a new project with `boot -d degree9/meta project --generate`